### PR TITLE
Stempler и атрибуты

### DIFF
--- a/src/Bootloader/ValidationBootloader.php
+++ b/src/Bootloader/ValidationBootloader.php
@@ -45,7 +45,7 @@ final class ValidationBootloader extends Bootloader
         FactoryInterface $factory
     ): SymfonyValidator {
         $validator = \Symfony\Component\Validator\Validation::createValidatorBuilder()
-            ->enableAnnotationMapping()
+            ->enableAttributeMapping()
             ->setConstraintValidatorFactory($constraintValidatorFactory);
 
         if ($container->has(TranslatorInterface::class)) {

--- a/src/Template/Stempler/NodeVisitor.php
+++ b/src/Template/Stempler/NodeVisitor.php
@@ -25,9 +25,11 @@ final class NodeVisitor implements VisitorInterface
 
                 return $c;
             }
+
+            return $node;
         }
 
-        return $node;
+        return null;
     }
 
     public function leaveNode(mixed $node, VisitorContext $ctx): mixed

--- a/tests/views/template/stempler/component-renderer-test/components/counter.dark.php
+++ b/tests/views/template/stempler/component-renderer-test/components/counter.dark.php
@@ -1,4 +1,4 @@
-<div>
+<div style="text-align: center">
     <button wire:click="increment">+</button>
     <h1>{{ $count }}</h1>
 </div>


### PR DESCRIPTION
Ошибка, когда мы используем stempler и прописываем тегам атрибуты. В частности пример из документации (counter) не работает.
Ошибка в тестах (enableAnnotationMapping()).